### PR TITLE
Deprecate UnPack

### DIFF
--- a/src/ParametrisedConvexApproximators.jl
+++ b/src/ParametrisedConvexApproximators.jl
@@ -1,7 +1,6 @@
 module ParametrisedConvexApproximators
 
 using Flux
-using UnPack
 using Convex
 using SCS  # 211207; currently not compatible with apple silicon
 using Optim

--- a/src/approximators/parametrised_convex_approximators/PLSE.jl
+++ b/src/approximators/parametrised_convex_approximators/PLSE.jl
@@ -23,7 +23,7 @@ x and u should be arrays.
 For example, u = [1] for the one-element case.
 """
 function (nn::PLSE)(x::AbstractArray, u::AbstractArray)
-    @unpack T = nn
+    (; T) = nn
     is_vector = length(size(x)) == 1
     @assert is_vector == (length(size(u)) == 1)
     x = is_vector ? reshape(x, :, 1) : x
@@ -35,7 +35,7 @@ function (nn::PLSE)(x::AbstractArray, u::AbstractArray)
 end
 
 function (nn::PLSE)(x::AbstractArray, u::Convex.AbstractExpr)
-    @unpack T = nn
+    (; T) = nn
     tmp = affine_map(nn, x, u)
     res = [T * Convex.logsumexp((1/T)*tmp)]
 end

--- a/src/approximators/parametrised_convex_approximators/PMA.jl
+++ b/src/approximators/parametrised_convex_approximators/PMA.jl
@@ -3,8 +3,6 @@ struct PMA <: ParametrisedConvexApproximator
     m::Int
     i_max::Int
     NN::Flux.Chain
-    # NN1::Flux.Chain
-    # NN2::Flux.Chain
 end
 
 """

--- a/src/approximators/parametrised_convex_approximators/convex_approximators/LSE.jl
+++ b/src/approximators/parametrised_convex_approximators/convex_approximators/LSE.jl
@@ -46,14 +46,14 @@ Considering univariate function approximator
 """
 function (nn::LSE)(z::AbstractArray)
     is_vector = length(size(z)) == 1
-    @unpack T = nn
+    (; T) = nn
     z_affine = affine_map(nn, z)
     _res = T * Flux.logsumexp((1/T)*z_affine; dims=1)
     res = is_vector ? reshape(_res, 1) : _res
 end
 
 function (nn::LSE)(z::Convex.AbstractExpr)
-    @unpack T = nn
+    (; T) = nn
     z_affine = affine_map(nn, z)
     _res = [T * Convex.logsumexp((1/T)*z_affine)]
 end

--- a/src/approximators/parametrised_convex_approximators/convex_approximators/convex_approximators.jl
+++ b/src/approximators/parametrised_convex_approximators/convex_approximators/convex_approximators.jl
@@ -11,12 +11,12 @@ function _construct_convex_approximator(α_is::AbstractVector, β_is::AbstractVe
 end
 
 function affine_map(nn::ConvexApproximator, z::AbstractArray)
-    @unpack _α_is, _β_is = nn
+    (; _α_is, _β_is) = nn
     _α_is * z .+ _β_is
 end
 
 function affine_map(nn::ConvexApproximator, z::Convex.AbstractExpr)
-    @unpack _α_is, _β_is = nn
+    (; _α_is, _β_is) = nn
     _α_is * z + (_α_is*zeros(size(z)) .+ _β_is)
 end
 

--- a/src/approximators/parametrised_convex_approximators/parametrised_convex_approximators.jl
+++ b/src/approximators/parametrised_convex_approximators/parametrised_convex_approximators.jl
@@ -2,16 +2,14 @@ abstract type ParametrisedConvexApproximator <: AbstractApproximator end
 
 
 function affine_map(nn::ParametrisedConvexApproximator, x::AbstractArray, u::AbstractArray)
-    @unpack NN, i_max, m = nn
-    # @unpack NN1, NN2, i_max, m = nn
+    (; NN, i_max, m) = nn
     d = size(x)[2]
     X = reshape(NN(x), i_max, m+1, d)
     tmp = hcat([(X[:, 1:end-1, i]*u[:, i] .+ X[:, end:end, i]) for i in 1:d]...)
 end
 
 function affine_map(nn::ParametrisedConvexApproximator, x::AbstractArray, u::Convex.AbstractExpr)
-    @unpack NN, i_max, m = nn
-    # @unpack NN1, NN2, i_max, m = nn
+    (; NN, i_max, m) = nn
     X = reshape(NN(x), i_max, m+1)  # size(X1) = (i_max, m)
     tmp = (
            X[:, 1:end-1] * u + (X[:, 1:end-1]*zeros(size(u)) .+ X[:, end:end])

--- a/src/optimise.jl
+++ b/src/optimise.jl
@@ -49,7 +49,7 @@ Default solver is `IPNewton` in Optim.jl for box constraints [1].
 [1] https://julianlsolvers.github.io/Optim.jl/stable/#examples/generated/ipnewton_basics/#box-minimzation
 """
 function _optimise(approximator::AbstractApproximator, x::AbstractVector, u_min, u_max)
-    (; m = approximator)
+    (; m) = approximator
     obj(u) = approximator(x, u)[1]
     if u_min == nothing
         u_min = Float64[]  # no constraint

--- a/src/optimise.jl
+++ b/src/optimise.jl
@@ -16,7 +16,7 @@ Available solvers include SCS [2], COSMO [3], Mosek [4], etc.
 function _optimise(approximator::ParametrisedConvexApproximator, x::AbstractVector, u_min, u_max;
         solver=SCS,
     )
-    @unpack m = approximator
+    (; m) = approximator
     u = Convex.Variable(m)
     if u_min != nothing
         @assert length(u) == length(u_min)
@@ -49,7 +49,7 @@ Default solver is `IPNewton` in Optim.jl for box constraints [1].
 [1] https://julianlsolvers.github.io/Optim.jl/stable/#examples/generated/ipnewton_basics/#box-minimzation
 """
 function _optimise(approximator::AbstractApproximator, x::AbstractVector, u_min, u_max)
-    @unpack m = approximator
+    (; m = approximator)
     obj(u) = approximator(x, u)[1]
     if u_min == nothing
         u_min = Float64[]  # no constraint
@@ -77,7 +77,7 @@ function optimise(approximator::AbstractApproximator, x::AbstractVector;
     )
     minimiser, optval = _optimise(approximator, x, u_min, u_max)
     if minimiser == nothing
-        @unpack m = approximator
+        (; m) = approximator
         minimiser = repeat([nothing], m)
     end
     result = (; minimiser=minimiser, optval=optval)


### PR DESCRIPTION
Remove an unnecessary package from Julia 1.7, see [this](https://discourse.julialang.org/t/destructuring-syntax-in-julia-1-7/68236)